### PR TITLE
feat(course): Implements course deactivation via UI

### DIFF
--- a/alura-case-main/src/main/java/br/com/alura/projeto/course/Course.java
+++ b/alura-case-main/src/main/java/br/com/alura/projeto/course/Course.java
@@ -53,6 +53,11 @@ public class Course {
         this.category = category;
     }
 
+    public void inactivate() {
+        this.status = Status.INACTIVE;
+        this.inactivationDate = LocalDateTime.now();
+    }
+
     public String getName() { return name; }
     public String getCode() { return code; }
     public User getInstructor() { return instructor; }

--- a/alura-case-main/src/main/java/br/com/alura/projeto/course/CourseController.java
+++ b/alura-case-main/src/main/java/br/com/alura/projeto/course/CourseController.java
@@ -58,8 +58,13 @@ public class CourseController {
     }
 
     @PostMapping("/course/{code}/inactive")
+    @Transactional
     public ResponseEntity<?> updateStatus(@PathVariable("code") String courseCode) {
-        // TODO: Implementar a Questão 2 - Inativação de Curso aqui...
-        return ResponseEntity.ok().build();
+        return courseRepository.findByCode(courseCode)
+                .map(course -> {
+                    course.inactivate();
+                    return ResponseEntity.ok().build();
+                })
+                .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/alura-case-main/src/main/java/br/com/alura/projeto/course/CourseRepository.java
+++ b/alura-case-main/src/main/java/br/com/alura/projeto/course/CourseRepository.java
@@ -1,7 +1,10 @@
 package br.com.alura.projeto.course;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
     boolean existsByCode(String code);
+
+    Optional<Course> findByCode(String code);
 }


### PR DESCRIPTION
This PR implements the course deactivation feature (Issue 2), including backend logic and integration with the user interface.

**Changes:**
- **Backend:** Created the endpoint `POST /course/{code}/inactive` in `CourseController` to change the course status to `INACTIVE` and record the deactivation date.

- **Frontend:** The course listing page (`list.jsp`) has been updated to:
- Display the deactivation date.
- Add an “Inactivate” button for active courses, which triggers the endpoint via `POST`.
- `CourseDTO` has been updated to include the new field.

**How to Test:**
1.  Go to the `/admin/courses` listing page.
2.  Click the “Deactivate” button for a course with status `ACTIVE`.
3.  Verify that the course status changes to `INACTIVE` and that the deactivation date is displayed.