### PR TITLE
feat(course): Implements course deactivation via UI

### DIFF
--- a/alura-case-main/src/main/java/br/com/alura/projeto/course/Course.java
+++ b/alura-case-main/src/main/java/br/com/alura/projeto/course/Course.java
@@ -63,4 +63,5 @@ public class Course {
     public User getInstructor() { return instructor; }
     public Category getCategory() { return category; }
     public Status getStatus() { return status; }
+    public LocalDateTime getInactivationDate() { return inactivationDate; }
 }

--- a/alura-case-main/src/main/java/br/com/alura/projeto/course/CourseDTO.java
+++ b/alura-case-main/src/main/java/br/com/alura/projeto/course/CourseDTO.java
@@ -1,7 +1,18 @@
 package br.com.alura.projeto.course;
 
-public record CourseDTO(String name, String code, String instructorName, String categoryName, Status status) {
+import java.time.format.DateTimeFormatter;
+
+public record CourseDTO(String name, String code, String instructorName, String categoryName, Status status, String inactivationDate) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
     public CourseDTO(Course course) {
-        this(course.getName(), course.getCode(), course.getInstructor().getName(), course.getCategory().getName(), course.getStatus());
+        this(
+                course.getName(),
+                course.getCode(),
+                course.getInstructor().getName(),
+                course.getCategory().getName(),
+                course.getStatus(),
+                course.getInactivationDate() != null ? course.getInactivationDate().format(FORMATTER) : ""
+        );
     }
 }

--- a/alura-case-main/src/main/webapp/WEB-INF/views/admin/course/list.jsp
+++ b/alura-case-main/src/main/webapp/WEB-INF/views/admin/course/list.jsp
@@ -24,6 +24,8 @@
                 <th>Instrutor</th>
                 <th>Categoria</th>
                 <th>Status</th>
+                <th>Data de Inativação</th>
+                <th>Ações</th>
             </tr>
             </thead>
             <tbody>
@@ -34,6 +36,14 @@
                     <td>${course.instructorName()}</td>
                     <td>${course.categoryName()}</td>
                     <td>${course.status()}</td>
+                    <td>${course.inactivationDate()}</td>
+                    <td>
+                        <c:if test="${course.status() == 'ACTIVE'}">
+                            <form action="/course/${course.code()}/inactive" method="post" style="display:inline;">
+                                <button type="submit" class="btn btn-warning btn-xs">Inativar</button>
+                            </form>
+                        </c:if>
+                    </td>
                 </tr>
             </c:forEach>
             </tbody>


### PR DESCRIPTION
This PR implements the course deactivation feature (Issue 2), including backend logic and integration with the user interface.

**Changes:**

- **Backend:** Created the endpoint `POST /course/{code}/inactive` in `CourseController` to change the course status to `INACTIVE` and record the deactivation date.

- **Frontend:** The course listing page (`list.jsp`) has been updated to:
- Display the deactivation date.
- Add an “Inactivate” button for active courses, which triggers the endpoint via `POST`.
- `CourseDTO` has been updated to include the new field.

**How to Test:**
1.  Access the `/admin/courses` listing page.
2.  Click the “Deactivate” button for a course with status `ACTIVE`.
3.  Verify that the course status changes to `INACTIVE` and that the deactivation date is displayed.