### PR TITLE
feat(admin): Adds student management page and improves API

### DIFF
--- a/alura-case-main/src/main/java/br/com/alura/projeto/user/UserAdminController.java
+++ b/alura-case-main/src/main/java/br/com/alura/projeto/user/UserAdminController.java
@@ -1,0 +1,57 @@
+package br.com.alura.projeto.user;
+
+import jakarta.validation.Valid;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.util.List;
+
+@Controller
+public class UserAdminController {
+
+    private final UserRepository userRepository;
+
+    public UserAdminController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/admin/students")
+    public String listStudents(Model model) {
+        List<UserListItemDTO> students = userRepository.findByRole(Role.STUDENT)
+                .stream()
+                .map(UserListItemDTO::new)
+                .toList();
+        model.addAttribute("students", students);
+        model.addAttribute("newStudentUserDTO", new NewStudentUserDTO());
+        return "admin/student/list";
+    }
+
+    @PostMapping("/admin/students/new")
+    public String createStudent(@Valid NewStudentUserDTO newStudentUserDTO, BindingResult result, Model model) {
+        if (result.hasErrors()) {
+            List<UserListItemDTO> students = userRepository.findByRole(Role.STUDENT)
+                    .stream()
+                    .map(UserListItemDTO::new)
+                    .toList();
+            model.addAttribute("students", students);
+            model.addAttribute("newStudentUserDTO", newStudentUserDTO);
+            return "admin/student/list";
+        }
+
+        if (userRepository.existsByEmail(newStudentUserDTO.getEmail())) {
+            result.rejectValue("email", "email.exists", "Email já cadastrado no sistema");
+            List<UserListItemDTO> students = userRepository.findByRole(Role.STUDENT)
+                    .stream()
+                    .map(UserListItemDTO::new)
+                    .toList();
+            model.addAttribute("students", students);
+            return "admin/student/list";
+        }
+
+        userRepository.save(newStudentUserDTO.toModel());
+        return "redirect:/admin/students";
+    }
+}

--- a/alura-case-main/src/main/java/br/com/alura/projeto/user/UserController.java
+++ b/alura-case-main/src/main/java/br/com/alura/projeto/user/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
 
     @Transactional
     @PostMapping("/user/newStudent")
-    public ResponseEntity newStudent(@RequestBody @Valid NewStudentUserDTO newStudent) {
+    public ResponseEntity<?> newStudent(@RequestBody @Valid NewStudentUserDTO newStudent) {
         if(userRepository.existsByEmail(newStudent.getEmail())) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(new ErrorItemDTO("email", "Email já cadastrado no sistema"));
@@ -32,7 +32,7 @@ public class UserController {
         User user = newStudent.toModel();
         userRepository.save(user);
 
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(new UserListItemDTO(user));
     }
 
     @GetMapping("/user/all")

--- a/alura-case-main/src/main/webapp/WEB-INF/views/admin/student/list.jsp
+++ b/alura-case-main/src/main/webapp/WEB-INF/views/admin/student/list.jsp
@@ -1,0 +1,73 @@
+<%@ page pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
+
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Gerenciamento de Alunos</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="stylesheet" type="text/css" href="/assets/external-libs/bootstrap/css/bootstrap.min.css">
+</head>
+
+<body>
+<div class="container">
+    <div class="row">
+        <div class="col-md-8">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h1>Alunos</h1>
+                </div>
+                <table class="panel-body table table-hover">
+                    <thead>
+                    <tr>
+                        <th>Nome</th>
+                        <th>Email</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <c:forEach items="${students}" var="student">
+                        <tr>
+                            <td>${student.name}</td>
+                            <td>${student.email}</td>
+                        </tr>
+                    </c:forEach>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="col-md-4">
+            <section class="panel panel-primary">
+                <div class="panel-heading">
+                    <h1>Cadastrar Novo Aluno</h1>
+                </div>
+                <div class="panel-body">
+                    <form:form modelAttribute="newStudentUserDTO" action="/admin/students/new" method="post">
+                        <div class="form-group">
+                            <label for="name">Nome:</label>
+                            <form:input path="name" id="name" cssClass="form-control" required="required"/>
+                            <form:errors path="name" cssClass="text-danger"/>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="email">Email:</label>
+                            <form:input path="email" id="email" cssClass="form-control" required="required"/>
+                            <form:errors path="email" cssClass="text-danger"/>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="password">Senha:</label>
+                            <form:password path="password" id="password" cssClass="form-control" required="required"/>
+                            <form:errors path="password" cssClass="text-danger"/>
+                        </div>
+
+                        <input class="btn btn-success" type="submit" value="Salvar"/>
+                    </form:form>
+                </div>
+            </section>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This PR introduces student management functionality in the admin area and improves the response of the user creation API.

- New Students page: A new interface has been created at /admin/students that allows you to list all students and register new students directly through the UI.

- Improvements to the Creation API: The POST /user/newStudent endpoint now returns the JSON of the newly created user in the response body, facilitating confirmation and use of the data on the frontend.